### PR TITLE
PR for issue #8425

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Additional OAuth configuration options have been added for 'oauth' authentication on the listener and the client. 
   On the listener `serverBearerTokenLocation` and `userNamePrefix` have been added. 
   On the client `accessTokenLocation`, `clientAssertion`, `clientAssertionLocation`, `clientAssertionType`, and `saslExtensions` have been added.
+* Set restricted security context as default in the Strimzi Helm chart.
 
 ## 0.42.0
 

--- a/helm-charts/helm3/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/helm3/strimzi-kafka-operator/values.yaml
@@ -34,7 +34,9 @@ tmpDirSizeLimit: 1Mi
 #   - name: JAVA_OPTS
 #     value: "-Xms256m -Xmx256m"
 
-extraEnvs: []
+extraEnvs:
+  - name: STRIMZI_POD_SECURITY_PROVIDER_CLASS
+    value: restricted
 
 tolerations: []
 affinity: {}
@@ -44,7 +46,17 @@ nodeSelector: {}
 priorityClassName: ""
 
 podSecurityContext: {}
-securityContext: {}
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
+
 rbac:
   create: yes
 serviceAccountCreate: yes


### PR DESCRIPTION
Set restricted security context as default in the Strimzi Helm chart

### Type of change

- Enhancement / new feature

### Description

This will enabled Pod Security Policy to resctricted:latest by default.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ X ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ X ] Reference relevant issue(s) and close them after merging
- [ X ] Update CHANGELOG.md
- [ ] Supply screenshots for visual changes, such as Grafana dashboards

